### PR TITLE
Fix addons path definition (at least for linux install) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,11 @@ conda install gdal
 * Create a new directory named `python`.
 * Copy the contents of the spaceblender python directory (created above) into the newly created python directory.  Top-level directories within the `python` directory should include: bin, conda-meta, docs, Examples, include, lib, share.
 
-
+### Linux: Python install from distro
+(Verified on Fedora27, Blender 2.79)
+* Install python3 and all the aforementioned python3 dependencies from your distro.
+* Clone the plugin repository in `~/.config/blender/2.79/scripts/addons/`
+* Launch 
+```
+blender -b -P ~/.config/blender/2.79/scripts/addons/SpaceBlender/space_blend.py inputdem.IMG
+```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#SpaceBlender
+# SpaceBlender
 
 
 Space Blender is a Blender plugin designed to generate flyover DTM videos from a 32-bit digital elevation model.
 
-##Requirements
+## Requirements
 Space Blender has the following dependencies:
 
 1. The Geospatial Data Abstraction Library (GDAL)
@@ -12,7 +12,7 @@ Space Blender has the following dependencies:
 
 These dependencies must be installed within the blender shipped version of Python 3.3.  See the installation section for instructions on meeting these dependencies
 
-##Command line Quick-Start
+## Command line Quick-Start
 For this quickstart, we make the assumption that Blender is already installed and accessible via the command line as `blender`.  If this is not the case, see installation (below).
 
 
@@ -38,7 +38,7 @@ where:
 *  `-a` A boolean flag defining whether stars are rendered.
 *  `-t` A texture applied to the input image, e.g. an orthoimage.
 
-###Example usage:
+### Example usage:
 While the usage examples all assume a mythical DEM 'inputdem.IMG', it is possible to use any GDAL support input data type.  The development team has tested Space Blender using `.IMG` and `.tif` file formats.
 
 * Render a default flyover image at low spatial resolution and the lowest possible rendering resolution.  This is an ideal way to test your installation.
@@ -53,7 +53,7 @@ blender -b -P space_blend.py -s 0.1 -r 180p inputdem.IMG
 blender -b -P space_blend.py -s inputdem.IMG
 ```
 
-##Installation
+## Installation
 The development team utilizes [Anaconda Python] (http://continuum.io/downloads) as their default python installation in part because of the ease of external package installation.  The installation described below makes use of Anaconda Python and replaces the python 3.3 that ships with Blender with an Anaconda installation.  This has been tested on Mac OS X and Scientific Linux.
 
 * Download and install Anaconda Python.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ blender -b -P space_blend.py -s inputdem.IMG
 ```
 
 ## Installation
-The development team utilizes [Anaconda Python] (http://continuum.io/downloads) as their default python installation in part because of the ease of external package installation.  The installation described below makes use of Anaconda Python and replaces the python 3.3 that ships with Blender with an Anaconda installation.  This has been tested on Mac OS X and Scientific Linux.
+The development team utilizes [Anaconda Python](http://continuum.io/downloads) as their default python installation in part because of the ease of external package installation.  The installation described below makes use of Anaconda Python and replaces the python 3.3 that ships with Blender with an Anaconda installation.  This has been tested on Mac OS X and Scientific Linux.
 
 * Download and install Anaconda Python.
 *  At the time of the last update to this ReadMe, Blender was using Python version 3.3.5.  So, we will create a virutal environment that mirrors the Blender installation:

--- a/flyover_module.py
+++ b/flyover_module.py
@@ -135,7 +135,7 @@ def getlinear_path(mesh):
         startblendery = yblenderextent
 
         #Extract the topopgraphic profile
-        topoprofile = mesh.basedem.arr[:,startpixelx]
+        topoprofile = mesh.basedem.arr[:,int(startpixelx)]
         yidx = np.arange(topoprofile.shape[0])
         mask = np.isnan(topoprofile)
         startz = topoprofile[~mask][0]

--- a/space_blend.py
+++ b/space_blend.py
@@ -11,6 +11,9 @@ from sys import platform as _platform
 import bpy
 from bpy.props import *
 from bpy_extras.io_utils import ImportHelper
+
+import addon_utils
+
 from SpaceBlender import blender_module
 from SpaceBlender import gdal_module
 from SpaceBlender import flyover_module
@@ -62,31 +65,43 @@ class SpaceBlender(object):
             # If user selected a colr we are going to run the gdal and merge processes
             # We need to dtermine which OS is being used and set the location of color files
             # and the merge script accordingly
+            paths = addon_utils.paths()
             if _platform == "linux" or _platform == "linux2":
             # linux
-                    # Strip out the image name to set texture location and append color choice.
+                       # Strip out the image name to set texture location and append color choice.
                 texture_location = self.filepath.split('/')[-1:]
                 texture_location = texture_location[0].split('.')[:1]
                 texture_location = os.getcwd()+'/'+texture_location[0]+'_'+self.color_pattern+'.tiff'
-                color_file = '/usr/share/blender/scripts/addons/SpaceBlender/color_maps/' + self.color_pattern + '.txt'
-                merge_location = '/usr/share/blender/scripts/addons/SpaceBlender/hsv_merge.py'
+                for path in paths:
+                    try:
+                        color_file = path + '/SpaceBlender/color_maps/' + self.color_pattern + '.txt'
+                        merge_location = path + '/SpaceBlender/hsv_merge.py'
+                    except:
+                        raise NameError("Could not load color maps (color_file) or merge script (merge_location)", color_file, merge_location)
             elif _platform == "darwin":
             # OS X
                         # Strip out the image name to set texture location and append color choice.
                 texture_location = self.filepath.split('/')[-1:]
                 texture_location = texture_location[0].split('.')[:1]
                 texture_location = os.getcwd()+'/'+texture_location[0]+'_'+self.color_pattern+'.tiff'
-                color_file = '/Applications/Blender/blender.app/Contents/MacOS/2.70/scripts/addons/SpaceBlender/color_maps/'\
-                    + self.color_pattern + '.txt'
-                merge_location = '/Applications/Blender/blender.app/Contents/MacOS/2.70/scripts/addons/SpaceBlender/hsv_merge.py'
+                for path in paths:
+                    try:
+                        color_file = path + '/SpaceBlender/color_maps/' + self.color_pattern + '.txt'
+                        merge_location = path + '/SpaceBlender/hsv_merge.py'
+                    except:
+                        raise NameError("Could not load color maps (color_file) or merge script (merge_location)", color_file, merge_location)
             elif _platform == "win32":
             # Windows.
                 # Strip out the image name to set texture location and append color choice.
                 texture_location = self.filepath.split('\\')[-1:]
                 texture_location = texture_location[0].split('.')[:1]
                 texture_location = os.getcwd()+'\\'+texture_location[0]+'_'+self.color_pattern+'.tiff'
-                color_file = '"'+'C:\\Program Files\\Blender Foundation\\Blender\\2.69\\scripts\\addons\\SpaceBlender\\color_maps\\'+self.color_pattern + '.txt'+'"'
-                merge_location = '"'+'C:\\Program Files\\Blender Foundation\\Blender\\2.69\scripts\\addons\\SpaceBlender\\hsv_merge.py'+'"'
+                for path in paths:
+                    try:
+                        color_file = '"'+ path + '\\SpaceBlender\\color_maps\\'+self.color_pattern + '.txt'+'"'
+                        merge_location = '"'+ path + '\\SpaceBlender\\hsv_merge.py'+'"'
+                    except:
+                        raise NameError("Could not load color maps (color_file) or merge script (merge_location)", color_file, merge_location)
 
             gdal = gdal_module.GDALDriver(dtm_location)
             gdal.gdal_hillshade(hill_shade)


### PR DESCRIPTION
Hello,
on linux without a root installation,  the plugin was unable to find the standard user addons path, and then the default texture and color maps.
The fix has not been tested on a conda installation..
Hope it can be useful anyway.

Best
Chiara