### PR TITLE
Mapping of some flyover patterns was missing.

### DIFF
--- a/blender_module.py
+++ b/blender_module.py
@@ -28,7 +28,7 @@ from bpy.ops import *
 from . import flyover_module as flyover
 from . import gdalio
 
-flyovers = {'linear':'LinearPattern'}
+flyovers = {'linear':'LinearPattern','circle':'CirclePattern','diamond':'DiamondPattern'}
 
 def placeobj(mesh, objname):
     """


### PR DESCRIPTION
Hello,
running the addon in batch mode with circular flyover throws the following error:
``
File "SpaceBlender/blender_module.py", line 410, in auto_render
    bpy.context.scene.camera = bpy.data.objects['Camera']
KeyError: 'bpy_prop_collection[key]: key "Camera" not found'
``
This is because CirclePattern (and DiamondPattern also) was'nt mapped in blender_module.py, hence patterns other than linear were not created for pipeline rendering.

Best,
Chiara